### PR TITLE
Meritの赤背景調整

### DIFF
--- a/pages/-TopMerit.vue
+++ b/pages/-TopMerit.vue
@@ -139,7 +139,6 @@ export default {
 
     @media screen and (min-width: 768px) {
         .p-merit {
-            background:linear-gradient(90deg,#E15F52 0%,#E15F52 43%,#FFEDE6 43%,#FFEDE6 100%);
             &__container {
                 padding-bottom: 90px;
             }
@@ -162,6 +161,12 @@ export default {
             &__contentsSection:nth-child(even) &__contentsSectionDescriptionNumber {
                 left: -75px
             }
+        }
+    }
+
+    @media screen and (min-width: 1024px) {
+        .p-merit {
+            background: linear-gradient(90deg, #E15F52 0%, #E15F52 43%, #FFEDE6 43%, #FFEDE6 100%);
         }
     }
 </style>


### PR DESCRIPTION
close #133 

`938px`から文字に被り始めていたため、iPad Proの幅`1024px`より小さい場合、カンプの`768px`表示の幅にするよう修正しました。
確認お願いします。