### PR TITLE
タイポ修正

### DIFF
--- a/pages/-TopMerit.vue
+++ b/pages/-TopMerit.vue
@@ -9,7 +9,7 @@
                     <div class="p-merit__contentsSectionDescription">
                         <span class="p-merit__contentsSectionDescriptionNumber">01</span>
                         <h2 class="c-textRed c-mb20 c-fs20 c-fwBold">制作会社運営スクール</h2>
-                        <p class="p-merit__contentsSectionDescriptionText">スキル的な部分を現場の延長線で。技術顧問だから。 実際の Web 制作会社の教育プログラムをそのまま学べます。実務で活かせるのはもちろん、実質OJTを受けているのと同じです。</p>
+                        <p class="p-merit__contentsSectionDescriptionText">スキル的な部分を現場の延長線で。技術顧問だから。実際のWeb制作会社の教育プログラムをそのまま学べます。実務で活かせるのはもちろん、実質OJTを受けているのと同じです。</p>
                     </div>
                 </div>
 
@@ -18,7 +18,7 @@
                     <div class="p-merit__contentsSectionDescription">
                         <span class="p-merit__contentsSectionDescriptionNumber">02</span>
                         <h2 class="c-textRed c-mb20 c-fs20 c-fwBold">講師はプロのエンジニア</h2>
-                        <p class="p-merit__contentsSectionDescriptionText">PHP・Vue.js を中心とするWeb制作を進めながら、技術顧問という肩書で関西の様々な制作現場の業務改善に取り組んでいます。制作現場での技術的な指導や設計レビュー、業務改善提案のほか、イベント・セミナーでの登壇など、「作る」だけでなく「伝える」ことに重きを置いた活動を続けてきました。</p>
+                        <p class="p-merit__contentsSectionDescriptionText">PHP・Vue.jsを中心とするWeb制作を進めながら、技術顧問という肩書で関西の様々な制作現場の業務改善に取り組んでいます。制作現場での技術的な指導や設計レビュー、業務改善提案のほか、イベント・セミナーでの登壇など、「作る」だけでなく「伝える」ことに重きを置いた活動を続けてきました。</p>
                     </div>
                 </div>
 

--- a/pages/-TopReason.vue
+++ b/pages/-TopReason.vue
@@ -16,7 +16,7 @@
                     <div class="p-reason__pointBox">
                         <img class="p-reason__pointBoxImage" src="~/assets/images/p-reason_img02@2x.png" alt="">
                         <h3 class="c-fs20 c-textRed c-fwBold">個別カリキュラム</h3>
-                        <p class="p-reason__pointBoxDescription">個人で作成しているサイトやプロジェクトなどの制作サポートを希望される方向けの、個別レッスン相談にも対応させていただきます。一般的な Web スクールよりも大幅に低価格で、短期集中型のスキルアップが可能です。</p>
+                        <p class="p-reason__pointBoxDescription">個人で作成しているサイトやプロジェクトなどの制作サポートを希望される方向けの、個別レッスン相談にも対応させていただきます。一般的なWebスクールよりも大幅に低価格で、短期集中型のスキルアップが可能です。</p>
                     </div>
                 </div>
             </div>   
@@ -26,7 +26,7 @@
                     <div class="p-reason__pointBox">
                         <img class="p-reason__pointBoxImage" src="~/assets/images/p-reason_img03@2x.png" alt="">
                         <h3 class="c-fs20 c-textRed c-fwBold">自分で学べる学習スタイル</h3>
-                        <p class="p-reason__pointBoxDescription">Lec Cafe はそれぞれのゴールを決めるところからスタートします。講座の進むスピードもそれぞれのせスキルレベルに応じて柔軟に変化するため、自分でやればやるほどスキルアップにかかる時間や費用を調整できます。</p>
+                        <p class="p-reason__pointBoxDescription">Lec Cafeはそれぞれのゴールを決めるところからスタートします。講座の進むスピードもそれぞれのスキルレベルに応じて柔軟に変化するため、自分でやればやるほどスキルアップにかかる時間や費用を調整できます。</p>
                     </div>
                 </div>
 


### PR DESCRIPTION
close #132 

- Merit
  - [x] 『実際の Web 制作会社』とWebの両端が半角空いているのでトル
  - [x] 『はじめのPHP・Vue.js』の後ろに半角スペース空いているのでトル
- Reason
  - [x] 『一般的な Web スクールよりも』とWebの両端が半角空いているのでトル
  - [x] 『Lec Cafe はそれぞれの』とCafeの後ろが半角空いているのでトル
  - [x] 『それぞれのせスキルレベル』と誤字があるので『 せ』を消して欲しい

上記のタイポの修正をしましたので確認お願いします。